### PR TITLE
Align required_ruby_version with actually supported versions

### DIFF
--- a/lib-ruby-parser.gemspec
+++ b/lib-ruby-parser.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'Ruby parser written in Rust.'
   spec.description   = 'Ruby bindings for lib-ruby-parser.'
   spec.homepage      = 'https://github.com/lib-ruby-parser/ruby-bindings'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/lib-ruby-parser/ruby-bindings'

--- a/package/aarch64-apple-darwin-gemspec.rb
+++ b/package/aarch64-apple-darwin-gemspec.rb
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Ruby bindings for lib-ruby-parser.'
   spec.homepage      = 'https://github.com/lib-ruby-parser/ruby-bindings'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>=3.0.0')
   spec.platform              = 'arm64-darwin'
 
   spec.metadata['homepage_uri'] = spec.homepage

--- a/package/x86_64-apple-darwin-gemspec.rb
+++ b/package/x86_64-apple-darwin-gemspec.rb
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Ruby bindings for lib-ruby-parser.'
   spec.homepage      = 'https://github.com/lib-ruby-parser/ruby-bindings'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>=3.0.0')
   spec.platform              = 'x86_64-darwin'
 
   spec.metadata['homepage_uri'] = spec.homepage

--- a/package/x86_64-pc-windows-gnu-gemspec.rb
+++ b/package/x86_64-pc-windows-gnu-gemspec.rb
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Ruby bindings for lib-ruby-parser.'
   spec.homepage      = 'https://github.com/lib-ruby-parser/ruby-bindings'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>=3.0.0')
   spec.platform              = 'x64-mingw32'
 
   spec.metadata['homepage_uri'] = spec.homepage

--- a/package/x86_64-unknown-linux-gnu-gemspec.rb
+++ b/package/x86_64-unknown-linux-gnu-gemspec.rb
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'Ruby bindings for lib-ruby-parser.'
   spec.homepage      = 'https://github.com/lib-ruby-parser/ruby-bindings'
 
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
+  spec.required_ruby_version = Gem::Requirement.new('>=3.0.0')
   spec.platform              = 'x86_64-linux'
 
   spec.metadata['homepage_uri'] = spec.homepage


### PR DESCRIPTION
Fixes https://github.com/lib-ruby-parser/ruby-bindings/issues/16